### PR TITLE
Multiple accounts

### DIFF
--- a/harbour-tooterb.pro
+++ b/harbour-tooterb.pro
@@ -56,6 +56,7 @@ DISTFILES += qml/harbour-tooterb.qml \
     qml/pages/ConversationPage.qml \
     qml/pages/ProfilePage.qml \
     qml/pages/SettingsPage.qml \
+    qml/pages/components/HoldInteractionHint.qml \
     qml/pages/components/InfoBanner.qml \
     qml/pages/components/MediaFullScreen.qml \
     qml/pages/components/MyMedia.qml \

--- a/qml/harbour-tooterb.qml
+++ b/qml/harbour-tooterb.qml
@@ -86,8 +86,6 @@ ApplicationWindow {
             }
         })
         Logic.init()
-
-
     }
 
     Component.onDestruction: {

--- a/qml/harbour-tooterb.qml
+++ b/qml/harbour-tooterb.qml
@@ -45,6 +45,8 @@ ApplicationWindow {
             //console.log(JSON.stringify(Logic.conf))
             if (!Logic.conf['notificationLastID'])
                 Logic.conf['notificationLastID'] = 0
+            if (!('type' in Logic.conf))
+                Logic.conf.type = 0
 
             if (Logic.conf['instance']) {
                 Logic.api = Logic.mastodonAPI({

--- a/qml/harbour-tooterb.qml
+++ b/qml/harbour-tooterb.qml
@@ -63,16 +63,18 @@ ApplicationWindow {
                 Logic.conf.activeAccount = Logic.conf.accounts.length - 1
             }
 
-            if (Logic.conf['instance']) {
+            var currentAccount = Logic.getActiveAccount()
+
+            if (currentAccount.instance) {
                 Logic.api = Logic.mastodonAPI({
-                                                  "instance": Logic.conf['instance'],
+                                                  "instance": currentAccount.instance,
                                                   "api_user_token": ""
                                               })
             }
 
-            if (Logic.conf['login']) {
+            if (currentAccount.login) {
                 //Logic.conf['notificationLastID'] = 0
-                Logic.api.setConfig("api_user_token", Logic.conf['api_user_token'])
+                Logic.api.setConfig("api_user_token", currentAccount['api_user_token'])
                 //accounts/verify_credentials
                 Logic.api.get('instance', [], function(data) {
                    // console.log(JSON.stringify(data))

--- a/qml/harbour-tooterb.qml
+++ b/qml/harbour-tooterb.qml
@@ -45,8 +45,23 @@ ApplicationWindow {
             //console.log(JSON.stringify(Logic.conf))
             if (!Logic.conf['notificationLastID'])
                 Logic.conf['notificationLastID'] = 0
-            if (!('type' in Logic.conf))
-                Logic.conf.type = 0
+            if (!Logic.conf['accounts'])
+                Logic.conf['accounts'] = []
+
+            var oldAccountParameters = ['api_user_token', 'instance', 'login']
+            if (oldAccountParameters.every(function(el) { return el in Logic.conf })) {
+                if (!('type' in Logic.conf))
+                    Logic.conf.type = 0
+                oldAccountParameters.push('type')
+
+                var account = {}
+                oldAccountParameters.forEach(function(el) {
+                    account[el] = Logic.conf[el]
+                    Logic.conf[el] = null
+                })
+                Logic.conf.accounts.push(account)
+                Logic.conf.activeAccount = Logic.conf.accounts.length - 1
+            }
 
             if (Logic.conf['instance']) {
                 Logic.api = Logic.mastodonAPI({

--- a/qml/lib/API.js
+++ b/qml/lib/API.js
@@ -31,6 +31,11 @@ var mediator = (function(){
     };
 }());
 
+function getActiveAccount() {
+    // not sure if this can be used for dynamic qobject properties
+    return conf.accounts[conf.activeAccount] || {}
+}
+
 var init = function(){
     console.log("db.version: "+db.version);
     if(db.version === '') {

--- a/qml/lib/API.js
+++ b/qml/lib/API.js
@@ -123,6 +123,11 @@ var modelTLnotifications = Qt.createQmlObject('import QtQuick 2.0; ListModel {  
 var modelTLsearch = Qt.createQmlObject('import QtQuick 2.0; ListModel {   }', Qt.application, 'InternalQmlObject');
 var modelTLbookmarks = Qt.createQmlObject('import QtQuick 2.0; ListModel {   }', Qt.application, 'InternalQmlObject');
 
+function clearModels() {
+    [modelTLhome, modelTLpublic, modelTLlocal, modelTLnotifications, modelTLsearch, modelTLbookmarks]
+        .forEach(function(m) { m.clear() })
+}
+
 var notificationsList = []
 
 var notificationGenerator = function(item){

--- a/qml/lib/API.js
+++ b/qml/lib/API.js
@@ -69,7 +69,7 @@ function saveData() {
     db.transaction(function(tx) {
         for (var key in conf) {
             if (conf.hasOwnProperty(key)){
-                console.log(key + "\t>\t"+conf[key]);
+                console.log(key + "\t>\t"+JSON.stringify(conf[key]));
                 if (typeof conf[key] === "object" && conf[key] === null) {
                     tx.executeSql('DELETE FROM settings WHERE key=? ', [key])
                 } else {

--- a/qml/lib/API.js
+++ b/qml/lib/API.js
@@ -36,6 +36,16 @@ function getActiveAccount() {
     return conf.accounts[conf.activeAccount] || {}
 }
 
+function setActiveAccount(index) {
+    var account = conf.accounts[index]
+    conf.activeAccount = index
+
+    api.setConfig("instance", account.instance)
+    api.setConfig("api_user_token", account.api_user_token)
+
+    clearModels()
+}
+
 var init = function(){
     console.log("db.version: "+db.version);
     if(db.version === '') {

--- a/qml/lib/Worker.js
+++ b/qml/lib/Worker.js
@@ -108,7 +108,7 @@ WorkerScript.onMessage = function(msg) {
             var item;
             if (data.hasOwnProperty(i)) {
                 if(msg.action === "accounts/search") {
-                    item = parseAccounts([], "", data[i]);
+                    item = parseAccounts({}, "", data[i]);
                     //console.log(JSON.stringify(data[i]))
                     console.log("has own data")
 

--- a/qml/lib/Worker.js
+++ b/qml/lib/Worker.js
@@ -41,8 +41,10 @@ WorkerScript.onMessage = function(msg) {
         }
     }
 
+    var account = msg.conf && msg.conf.accounts ? msg.conf.accounts[msg.conf.activeAccount] : undefined
+
     /** Logged-in status */
-    if (!msg.conf || !msg.conf.login) {
+    if (!account || !account.login) {
         //console.log("Not loggedin")
         return;
     }
@@ -54,7 +56,7 @@ WorkerScript.onMessage = function(msg) {
 
     /* init API statuses */
 
-    var API = mastodonAPI({ instance: msg.conf.instance, api_user_token: msg.conf.api_user_token});
+    var API = mastodonAPI({ instance: account.instance, api_user_token: account.api_user_token});
 
     /*
     * HEAD call for some actions

--- a/qml/lib/Worker.js
+++ b/qml/lib/Worker.js
@@ -103,6 +103,11 @@ WorkerScript.onMessage = function(msg) {
 
     API.get(msg.action, msg.params, function(data) {
 
+        if (msg.action === "accounts/verify_credentials") {
+            WorkerScript.sendMessage({action: msg.action, success: true, data: parseAccounts({}, '', data)})
+            return
+        }
+
         var items = [];
         //console.log(data)
 

--- a/qml/lib/Worker.js
+++ b/qml/lib/Worker.js
@@ -12,6 +12,8 @@ WorkerScript.onMessage = function(msg) {
     if (debug) console.log("Action > " + msg.action)
     if (debug) console.log("Mode > " + msg.mode)
 
+    msg.params = msg.params || []
+
     // this is not elegant. it's max_id and ids from MyList
     // we should always get max_id on append
     if (msg.mode === "append" && msg.params[0]) {

--- a/qml/pages/ConversationPage.qml
+++ b/qml/pages/ConversationPage.qml
@@ -403,6 +403,7 @@ Page {
 
         IconButton {
             id: btnAddMusic
+            visible: Logic.conf.type !== 1
             enabled: mediaModel.count < 4
             icon.source: "image://theme/icon-m-file-audio?" + ( pressed ? Theme.highlightColor : (warningContent.visible ? Theme.secondaryHighlightColor : Theme.primaryColor) )
             anchors {
@@ -424,7 +425,7 @@ Page {
             anchors {
                 top: toot.bottom
                 topMargin: -Theme.paddingSmall * 1.5
-                left: btnAddMusic.right
+                left: btnAddMusic.visible ? btnAddMusic.right : btnAddMusic.left
                 leftMargin: Theme.paddingSmall
             }
             onClicked: {

--- a/qml/pages/ConversationPage.qml
+++ b/qml/pages/ConversationPage.qml
@@ -43,10 +43,10 @@ Page {
 
     // This function is used by the upload Pickers
     function fileUpload(file,mime) {
-        imageUploader.setUploadUrl(Logic.conf.instance + "/api/v1/media")
+        imageUploader.setUploadUrl(Logic.getActiveAccount().instance + "/api/v1/media")
         imageUploader.setFile(file)
         imageUploader.setMime(mime)
-        imageUploader.setAuthorizationHeader(Logic.conf.api_user_token)
+        imageUploader.setAuthorizationHeader(Logic.getActiveAccount().api_user_token)
         imageUploader.upload()
     }
 
@@ -403,7 +403,7 @@ Page {
 
         IconButton {
             id: btnAddMusic
-            visible: Logic.conf.type !== 1
+            visible: Logic.getActiveAccount().type !== 1
             enabled: mediaModel.count < 4
             icon.source: "image://theme/icon-m-file-audio?" + ( pressed ? Theme.highlightColor : (warningContent.visible ? Theme.secondaryHighlightColor : Theme.primaryColor) )
             anchors {
@@ -442,10 +442,10 @@ Page {
                     var mimeType = selectedContentProperties.mimeType
                     fileUpload(imagePath,mimeType)
                     /*
-                    imageUploader.setUploadUrl(Logic.conf.instance + "/api/v1/media")
+                    imageUploader.setUploadUrl(Logic.getActiveAccount().instance + "/api/v1/media")
                     imageUploader.setFile(imagePath)
                     imageUploader.setMime(mimeType)
-                    imageUploader.setAuthorizationHeader(Logic.conf.api_user_token)
+                    imageUploader.setAuthorizationHeader(Logic.getActiveAccount().api_user_token)
                     imageUploader.upload()
                     */
                 }
@@ -519,7 +519,7 @@ Page {
         IconButton {
             id: btnSend
             icon.source: "image://theme/icon-m-send?" + (pressed ? Theme.highlightColor : Theme.primaryColor)
-            enabled: (toot.text !== "" || mediaModel.count > 0) && toot.text.length < tootMaxChar && uploadProgress.width == 0 && ((Logic.conf.type === 1 && type !== "reply") ? (mediaModel.count > 0) : true)
+            enabled: (toot.text !== "" || mediaModel.count > 0) && toot.text.length < tootMaxChar && uploadProgress.width == 0 && ((Logic.getActiveAccount().type === 1 && type !== "reply") ? (mediaModel.count > 0) : true)
             anchors {
                 top: toot.bottom
                 topMargin: -Theme.paddingSmall * 1.5

--- a/qml/pages/ConversationPage.qml
+++ b/qml/pages/ConversationPage.qml
@@ -519,7 +519,7 @@ Page {
         IconButton {
             id: btnSend
             icon.source: "image://theme/icon-m-send?" + (pressed ? Theme.highlightColor : Theme.primaryColor)
-            enabled: (toot.text !== "" || mediaModel.count > 0) && toot.text.length < tootMaxChar && uploadProgress.width == 0 && (Logic.conf.type === 1 ? (mediaModel.count > 0) : true)
+            enabled: (toot.text !== "" || mediaModel.count > 0) && toot.text.length < tootMaxChar && uploadProgress.width == 0 && ((Logic.conf.type === 1 && type !== "reply") ? (mediaModel.count > 0) : true)
             anchors {
                 top: toot.bottom
                 topMargin: -Theme.paddingSmall * 1.5

--- a/qml/pages/ConversationPage.qml
+++ b/qml/pages/ConversationPage.qml
@@ -518,7 +518,7 @@ Page {
         IconButton {
             id: btnSend
             icon.source: "image://theme/icon-m-send?" + (pressed ? Theme.highlightColor : Theme.primaryColor)
-            enabled: toot.text !== "" && toot.text.length < tootMaxChar && uploadProgress.width == 0
+            enabled: (toot.text !== "" || mediaModel.count > 0) && toot.text.length < tootMaxChar && uploadProgress.width == 0
             anchors {
                 top: toot.bottom
                 topMargin: -Theme.paddingSmall * 1.5

--- a/qml/pages/ConversationPage.qml
+++ b/qml/pages/ConversationPage.qml
@@ -518,7 +518,7 @@ Page {
         IconButton {
             id: btnSend
             icon.source: "image://theme/icon-m-send?" + (pressed ? Theme.highlightColor : Theme.primaryColor)
-            enabled: (toot.text !== "" || mediaModel.count > 0) && toot.text.length < tootMaxChar && uploadProgress.width == 0
+            enabled: (toot.text !== "" || mediaModel.count > 0) && toot.text.length < tootMaxChar && uploadProgress.width == 0 && (Logic.conf.type === 1 ? (mediaModel.count > 0) : true)
             anchors {
                 top: toot.bottom
                 topMargin: -Theme.paddingSmall * 1.5

--- a/qml/pages/LoginPage.qml
+++ b/qml/pages/LoginPage.qml
@@ -63,6 +63,8 @@ Page {
                     MenuItem { text: "Mastodon" }
                     MenuItem { text: "Pixelfed" }
                 }
+                Component.onCompleted: Logic.conf.type = currentIndex
+                onCurrentIndexChanged: Logic.conf.type = currentIndex
             }
             
             TextField {

--- a/qml/pages/LoginPage.qml
+++ b/qml/pages/LoginPage.qml
@@ -55,6 +55,7 @@ Page {
                     account["login"] = true
                     Logic.api.setConfig("api_user_token", account["api_user_token"])
                     pageStack.clear()
+                    Logic.clearModels()
                     pageStack.push(Qt.resolvedUrl("MainPage.qml"))
                 }
             }

--- a/qml/pages/LoginPage.qml
+++ b/qml/pages/LoginPage.qml
@@ -54,7 +54,8 @@ Page {
                     account["api_user_token"] = token.access_token
                     account["login"] = true
                     Logic.api.setConfig("api_user_token", account["api_user_token"])
-                    pageStack.replace(Qt.resolvedUrl("MainPage.qml"), {})
+                    pageStack.clear()
+                    pageStack.push(Qt.resolvedUrl("MainPage.qml"))
                 }
             }
 

--- a/qml/pages/LoginPage.qml
+++ b/qml/pages/LoginPage.qml
@@ -85,11 +85,13 @@ Page {
                                                   function(data) {
                                                       if (debug) console.log(data)
                                                       var conf = JSON.parse(data)
-                                                      conf.instance = instance.text;
-                                                      conf.type = typeBox.currentIndex
-                                                      conf.login = false;
 
-                                                      Logic.conf = conf;
+                                                      Logic.conf = {
+                                                          api_user_token: conf.api_user_token,
+                                                          instance: instance.text,
+                                                          type: typeBox.currentIndex,
+                                                          login: false,
+                                                      };
                                                       if(debug) console.log(JSON.stringify(conf))
                                                       if(debug) console.log(JSON.stringify(Logic.conf))
 

--- a/qml/pages/LoginPage.qml
+++ b/qml/pages/LoginPage.qml
@@ -36,8 +36,9 @@ Page {
                 redirectListener.port: 7538
 
                 // Workaround for Pixelfed
-                redirectUri: Logic.conf.type === 1 ? ' ' : redirectListener.uri
-                customParameters: Logic.conf.type === 1 ?
+                // For some reason Logic.conf.type does not send signal when it is changed, so we use the value from combo box
+                redirectUri: typeBox.currentIndex === 1 ? ' ' : redirectListener.uri
+                customParameters: typeBox.currentIndex === 1 ?
                                       ({redirect_uris: "http://127.0.0.1:7538"})
                                     : ({})
 
@@ -63,8 +64,6 @@ Page {
                     MenuItem { text: "Mastodon" }
                     MenuItem { text: "Pixelfed" }
                 }
-                Component.onCompleted: Logic.conf.type = currentIndex
-                onCurrentIndexChanged: Logic.conf.type = currentIndex
             }
             
             TextField {

--- a/qml/pages/LoginPage.qml
+++ b/qml/pages/LoginPage.qml
@@ -50,9 +50,10 @@ Page {
 
                 onReceivedAccessToken: {
                     if (debug) console.log("Got access token: " + token.access_token)
-                    Logic.conf["api_user_token"] = token.access_token
-                    Logic.conf["login"] = true;
-                    Logic.api.setConfig("api_user_token", Logic.conf["api_user_token"])
+                    var account = Logic.getActiveAccount()
+                    account["api_user_token"] = token.access_token
+                    account["login"] = true
+                    Logic.api.setConfig("api_user_token", account["api_user_token"])
                     pageStack.replace(Qt.resolvedUrl("MainPage.qml"), {})
                 }
             }
@@ -86,19 +87,20 @@ Page {
                                                       if (debug) console.log(data)
                                                       var conf = JSON.parse(data)
 
-                                                      Logic.conf = {
+                                                      Logic.conf.accounts.push({
                                                           api_user_token: conf.api_user_token,
                                                           instance: instance.text,
                                                           type: typeBox.currentIndex,
                                                           login: false,
-                                                      };
+                                                      })
+                                                      Logic.conf.activeAccount = Logic.conf.accounts.length - 1
                                                       if(debug) console.log(JSON.stringify(conf))
                                                       if(debug) console.log(JSON.stringify(Logic.conf))
 
                                                       // we got our application
 
                                                       mastodonOAuth.clientId = conf["client_id"]
-                                                      mastodonOAuth.clientSecret = conf["client_secret"];
+                                                      mastodonOAuth.clientSecret = conf["client_secret"]
 
                                                       mastodonOAuth.redirectListener.startListening() // Workaround for Pixelfed
                                                       mastodonOAuth.authorizeInBrowser()

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -29,6 +29,19 @@ Page {
 
                 slideshow.positionViewAtIndex(vIndex, ListView.SnapToItem)
             }
+
+            menu: Component {
+                ContextMenu {
+                    Repeater {
+                        model: Logic.conf.accounts
+                        MenuItem {
+                            enabled: index !== Logic.conf.activeAccount
+                            text: modelData.userInfo.account_acct
+                            onClicked: Logic.setActiveAccount(index)
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -29,20 +29,6 @@ Page {
 
                 slideshow.positionViewAtIndex(vIndex, ListView.SnapToItem)
             }
-
-            menu: Component {
-                ContextMenu {
-                    hasContent: Logic.conf.accounts.length > 1
-                    Repeater {
-                        model: Logic.conf.accounts
-                        MenuItem {
-                            enabled: index !== Logic.conf.activeAccount
-                            text: modelData.userInfo.account_acct
-                            onClicked: Logic.setActiveAccount(index)
-                        }
-                    }
-                }
-            }
         }
     }
 

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -310,6 +310,19 @@ Page {
         }
     }
 
+    WorkerScript {
+        id: worker
+        source: "../lib/Worker.js"
+        onMessage: {
+            if (debug) console.log(JSON.stringify(messageObject))
+            if (messageObject.action === "accounts/verify_credentials") {
+                Logic.getActiveAccount().userInfo = messageObject.data
+            }
+        }
+
+        Component.onCompleted: sendMessage({action: "accounts/verify_credentials", conf: Logic.conf})
+    }
+
     Component.onCompleted: {
         //console.log("aaa")
     }

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -46,6 +46,15 @@ Page {
         }
     }
 
+    InteractionHintLabel {
+        z: 1
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: infoPanel.visibleSize
+        text: qsTr("Press and hold the home tab to switch account")
+        opacity: navigation.showInteractionHintLabel && infoPanel.visible ? 1 : 0
+        Behavior on opacity { FadeAnimator {} }
+    }
+
     VisualItemModel {
         id: visualModel
 

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -17,12 +17,13 @@ Page {
         id: infoPanel
         open: true
         width: isPortrait ? parent.width : Theme.itemSizeLarge
-        height: isPortrait ? Theme.itemSizeLarge : parent.height
+        height: isPortrait ? (Theme.itemSizeLarge + navigation.menuHeight) : parent.height
         dock: isPortrait ? Dock.Bottom : Dock.Right
 
         NavigationPanel {
             id: navigation
-            isPortrait: !mainPage.isPortrait
+            isPortrait: mainPage.isPortrait
+            dockedPanelMouseArea: parent
             onSlideshowShow: {
                 if (debug) console.log(vIndex)
 

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -43,6 +43,8 @@ Page {
             width: isPortrait ? parent.itemWidth : parent.itemWidth - Theme.itemSizeLarge
             height: parent.itemHeight
             onOpenDrawer: isPortrait ? infoPanel.open = setDrawer : infoPanel.open = true
+
+            onCountChanged: if (count == 0) worker.verifyCredentials()
         }
 
         MyList {
@@ -323,7 +325,11 @@ Page {
             }
         }
 
-        Component.onCompleted: sendMessage({action: "accounts/verify_credentials", conf: Logic.conf})
+        function verifyCredentials() {
+            sendMessage({action: "accounts/verify_credentials", conf: Logic.conf})
+        }
+
+        Component.onCompleted: verifyCredentials()
     }
 
     Component.onCompleted: {

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -32,6 +32,7 @@ Page {
 
             menu: Component {
                 ContextMenu {
+                    hasContent: Logic.conf.accounts.length > 1
                     Repeater {
                         model: Logic.conf.accounts
                         MenuItem {

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -317,6 +317,8 @@ Page {
             if (debug) console.log(JSON.stringify(messageObject))
             if (messageObject.action === "accounts/verify_credentials") {
                 Logic.getActiveAccount().userInfo = messageObject.data
+                Logic.getActiveAccount().userInfo.account_acct += "@" + (Logic.getActiveAccount()['instance'].split("//")[1])
+                delete Logic.getActiveAccount().userInfo.account_id
             }
         }
 

--- a/qml/pages/ProfilePage.qml
+++ b/qml/pages/ProfilePage.qml
@@ -115,9 +115,14 @@ Page {
             if (user.indexOf('@') == 0)
                 user = user.slice(1)
             user = user.replace('@'+Logic.getActiveAccount().instance.split('//')[1], "")
+            var resolve = user.indexOf('@') > -1
+
+            if (resolve && Logic.getActiveAccount().type === 1)
+                // With Pixelfed and "@" in q parameter, it returns 404 and crashes, so we disable this for now
+                return
 
             worker.sendMessage({
-                'action'    : "accounts/search?limit=1&q=" + user + '&resolve=' + (user.indexOf('@') > -1),
+                'action'    : "accounts/search?limit=1&q=" + user + '&resolve=' + resolve,
                 'conf'      : Logic.conf
             })
         }

--- a/qml/pages/ProfilePage.qml
+++ b/qml/pages/ProfilePage.qml
@@ -47,7 +47,7 @@ Page {
 
                 var msg = {
                     'action'    : "accounts/relationships/",
-                    'params'    : [ {name: "id", data: user_id}],
+                    'params'    : [ {name: Logic.conf.type === 1 ? "id[]" : "id", data: user_id}],
                     'conf'      : Logic.conf
                 };
                 worker.sendMessage(msg);
@@ -108,7 +108,7 @@ Page {
         if (user_id) {
             msg = {
                 'action'    : "accounts/relationships/",
-                'params'    : [ {name: "id", data: user_id} ],
+                'params'    : [ {name: Logic.conf.type === 1 ? "id[]" : "id", data: user_id} ],
                 'conf'      : Logic.conf
             }
             worker.sendMessage(msg)

--- a/qml/pages/ProfilePage.qml
+++ b/qml/pages/ProfilePage.qml
@@ -103,23 +103,23 @@ Page {
     // The effective value will be restricted by ApplicationWindow.allowedOrientations
     allowedOrientations: Orientation.All
     Component.onCompleted: {
-        var msg
-
         if (user_id) {
-            msg = {
+            worker.sendMessage({
                 'action'    : "accounts/relationships/",
                 'params'    : [ {name: "id[]", data: user_id} ],
                 'conf'      : Logic.conf
-            }
-            worker.sendMessage(msg)
+            })
 
         } else {
-            var instance = Logic.getActiveAccount()['instance'].split("//")
-            msg = {
-                'action'    : "accounts/search?limit=1&q="+username.replace("@"+instance[1], ""),
+            var user = username
+            if (user.indexOf('@') == 0)
+                user = user.slice(1)
+            user = user.replace('@'+Logic.getActiveAccount().instance.split('//')[1], "")
+
+            worker.sendMessage({
+                'action'    : "accounts/search?limit=1&q=" + user + '&resolve=' + (user.indexOf('@') > -1),
                 'conf'      : Logic.conf
-            }
-            worker.sendMessage(msg)
+            })
         }
     }
 

--- a/qml/pages/ProfilePage.qml
+++ b/qml/pages/ProfilePage.qml
@@ -47,7 +47,7 @@ Page {
 
                 var msg = {
                     'action'    : "accounts/relationships/",
-                    'params'    : [ {name: Logic.conf.type === 1 ? "id[]" : "id", data: user_id}],
+                    'params'    : [ {name: Logic.getActiveAccount().type === 1 ? "id[]" : "id", data: user_id}],
                     'conf'      : Logic.conf
                 };
                 worker.sendMessage(msg);
@@ -108,13 +108,13 @@ Page {
         if (user_id) {
             msg = {
                 'action'    : "accounts/relationships/",
-                'params'    : [ {name: Logic.conf.type === 1 ? "id[]" : "id", data: user_id} ],
+                'params'    : [ {name: Logic.getActiveAccount().type === 1 ? "id[]" : "id", data: user_id} ],
                 'conf'      : Logic.conf
             }
             worker.sendMessage(msg)
 
         } else {
-            var instance = Logic.conf['instance'].split("//")
+            var instance = Logic.getActiveAccount()['instance'].split("//")
             msg = {
                 'action'    : "accounts/search?limit=1&q="+username.replace("@"+instance[1], ""),
                 'conf'      : Logic.conf

--- a/qml/pages/ProfilePage.qml
+++ b/qml/pages/ProfilePage.qml
@@ -281,7 +281,7 @@ Page {
                         onClicked: {
                             pageStack.push(Qt.resolvedUrl("ConversationPage.qml"), {
                                                headerTitle: qsTr("Mention"),
-                                               description: "@"+username,
+                                               username: "@"+username,
                                                type: "new"
                                            })
                         }

--- a/qml/pages/ProfilePage.qml
+++ b/qml/pages/ProfilePage.qml
@@ -47,7 +47,7 @@ Page {
 
                 var msg = {
                     'action'    : "accounts/relationships/",
-                    'params'    : [ {name: Logic.getActiveAccount().type === 1 ? "id[]" : "id", data: user_id}],
+                    'params'    : [ {name: "id[]", data: user_id}],
                     'conf'      : Logic.conf
                 };
                 worker.sendMessage(msg);
@@ -108,7 +108,7 @@ Page {
         if (user_id) {
             msg = {
                 'action'    : "accounts/relationships/",
-                'params'    : [ {name: Logic.getActiveAccount().type === 1 ? "id[]" : "id", data: user_id} ],
+                'params'    : [ {name: "id[]", data: user_id} ],
                 'conf'      : Logic.conf
             }
             worker.sendMessage(msg)

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -226,7 +226,7 @@ Page {
                                     var m = Qt.createQmlObject('import QtQuick 2.0; ListModel { }', Qt.application, 'InternalQmlObject');
                                     pageStack.push(Qt.resolvedUrl("ConversationPage.qml"), {
                                                        headerTitle: "Mention",
-                                                       description: '@'+model.mastodon,
+                                                       username: '@'+model.mastodon,
                                                        type: "new"
                                                    })
                                 } else {

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -200,6 +200,13 @@ Page {
                             mastodon: ""
                             mail: ""
                         }
+
+                        ListElement {
+                            name: "roundedrectangle"
+                            desc: qsTr("Pixelfed support")
+                            mastodon: "roundedrectangle@techhub.social"
+                            mail: ""
+                        }
                     }
 
                     Item {

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -44,19 +44,20 @@ Page {
 
             SectionHeader { text: qsTr("Account") }
 
+            signal activeAccountChanged
             function setActiveAccount(index, removing) {
-                if (Logic.conf.activeAccount === index) return
+                if (!removing && Logic.conf.activeAccount === index) return
                 var account = Logic.conf.accounts[index]
 
                 Logic.conf.activeAccount = index
 
                 Logic.api.setConfig("instance", account.instance)
                 Logic.api.setConfig("api_user_token", account.api_user_token)
-                Logic.clearModels()
 
-                pageStack.pop(null, PageStackAction.Immediate)
-                pageStack.replace(Qt.resolvedUrl("MainPage.qml"), null, PageStackAction.Immediate)
-                pageStack.push(Qt.resolvedUrl("SettingsPage.qml"), null, PageStackAction.Immediate)
+                Logic.clearModels()
+                if (removing)
+                    accountsList.model = Logic.conf.accounts
+                else activeAccountChanged()
             }
 
             Repeater {
@@ -66,6 +67,11 @@ Page {
                     id: userItem
                     property var model: modelData.userInfo
                     textHighlighted: index === Logic.conf.activeAccount
+
+                    Connections {
+                        target: column
+                        onActiveAccountChanged: textHighlighted = index === Logic.conf.activeAccount
+                    }
 
                     onClicked: column.setActiveAccount(index)
 

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -39,10 +39,100 @@ Page {
 
             SectionHeader { text: qsTr("Account") }
 
+            signal activeAccountChanged
+
+            Repeater {
+                model: Logic.conf.accounts
+                Item {
+                    id: removeAccount
+                    width: parent.width
+                    height: clnRemoveAccount.height + Theme.paddingLarge
+                    anchors {
+                        left: parent.left
+                        leftMargin: Theme.horizontalPageMargin
+                        right: parent.right
+                        rightMargin: Theme.paddingLarge
+                    }
+
+                    Icon {
+                        id: icnRemoveAccount
+                        color: Theme.highlightColor
+                        width: Theme.iconSizeMedium
+                        fillMode: Image.PreserveAspectFit
+                        source: "image://theme/icon-m-contact"
+                        anchors.right: parent.right
+                    }
+
+                    Column {
+                        id: clnRemoveAccount
+                        spacing: Theme.paddingMedium
+                        anchors {
+                            left: parent.left
+                            right: icnRemoveAccount.left
+                        }
+
+                        SectionHeader {
+                            text: index + modelData.api_user_token
+                            height: implicitHeight
+                            wrapMode: Text.Wrap
+                        }
+
+                        Button {
+                            id: activateButton
+                            text: qsTr("Activate")
+                            enabled: index !== Logic.conf.activeAccount
+                            onClicked: {
+                                Logic.conf.activeAccount = index
+                                column.activeAccountChanged()
+                                Logic.api.setConfig("instance", modelData.instance)
+                                Logic.api.setConfig("api_user_token", modelData.api_user_token)
+                            }
+
+                            Connections {
+                                target: column
+                                onActiveAccountChanged: activateButton.enabled = index !== Logic.conf.activeAccount
+                            }
+                        }
+
+                        Button {
+                            id: btnRemoveAccount
+                            text: qsTr("Remove Account")
+                            preferredWidth: Theme.buttonWidthMedium
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            onClicked: {
+                                remorsePopup.execute(btnRemoveAccount.text, function() {
+                                    Logic.conf.accounts.splice(index, 1)
+                                    if (Logic.conf.accounts.length == 0) {
+                                        Logic.conf.activeAccount = null
+                                        pageStack.push(Qt.resolvedUrl("LoginPage.qml"))
+                                    } else
+                                        Logic.conf.activeAccount = Logic.conf.accounts.length - 1
+                                })
+                            }
+
+                            Timer {
+                                interval: 4700
+                                onTriggered: parent.busy = false
+                            }
+                        }
+
+                        Label {
+                            id: txtRemoveAccount
+                            text: qsTr("Deauthorize this app from using your account and remove account data from phone")
+                            font.pixelSize: Theme.fontSizeExtraSmall
+                            wrapMode: Text.Wrap
+                            color: Theme.highlightColor
+                            width: parent.width - Theme.paddingMedium
+                            anchors.left: parent.left
+                        }
+                    }
+                }
+            }
+
             Item {
-                id: removeAccount
+                id: addAccount
                 width: parent.width
-                height: txtRemoveAccount.height + btnRemoveAccount.height + Theme.paddingLarge
+                height: clnAddAccount.height + Theme.paddingLarge
                 anchors {
                     left: parent.left
                     leftMargin: Theme.horizontalPageMargin
@@ -51,49 +141,40 @@ Page {
                 }
 
                 Icon {
-                    id: icnRemoveAccount
+                    id: icnAddAccount
                     color: Theme.highlightColor
                     width: Theme.iconSizeMedium
                     fillMode: Image.PreserveAspectFit
-                    source: Logic.conf['login'] ? "image://theme/icon-m-contact" : "image://theme/icon-m-add"
+                    source: "image://theme/icon-m-add"
                     anchors.right: parent.right
                 }
 
                 Column {
-                    id: clnRemoveAccount
+                    id: clnAddAccount
                     spacing: Theme.paddingMedium
                     anchors {
                         left: parent.left
-                        right: icnRemoveAccount.left
+                        right: icnAddAccount.left
                     }
 
                     Button {
-                        id: btnRemoveAccount
-                        text: Logic.conf['login'] ? qsTr("Remove Account") : qsTr("Add Account")
+                        id: btnAddAccount
+                        text: qsTr("Add Account")
                         preferredWidth: Theme.buttonWidthMedium
                         anchors.horizontalCenter: parent.horizontalCenter
                         onClicked: {
-                            remorsePopup.execute(btnRemoveAccount.text, function() {
-                                if (Logic.conf['login']) {
-                                    Logic.conf['login'] = false
-                                    Logic.conf['instance'] = null;
-                                    Logic.conf['api_user_token'] = null;
-                                    Logic.conf['type'] = null
-                                }
-                                pageStack.push(Qt.resolvedUrl("LoginPage.qml"))
-                            })
+                            pageStack.push(Qt.resolvedUrl("LoginPage.qml"))
                         }
 
                         Timer {
-                            id: timer1
                             interval: 4700
                             onTriggered: parent.busy = false
                         }
                     }
 
                     Label {
-                        id: txtRemoveAccount
-                        text: Logic.conf['login'] ? qsTr("Deauthorize this app from using your account and remove account data from phone") : qsTr("Authorize this app to access your Mastodon account")
+                        id: txtAddAccount
+                        text: qsTr("Authorize this app to access your Mastodon account")
                         font.pixelSize: Theme.fontSizeExtraSmall
                         wrapMode: Text.Wrap
                         color: Theme.highlightColor

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -47,14 +47,8 @@ Page {
             signal activeAccountChanged
             function setActiveAccount(index, removing) {
                 if (!removing && Logic.conf.activeAccount === index) return
-                var account = Logic.conf.accounts[index]
+                Logic.setActiveAccount(index)
 
-                Logic.conf.activeAccount = index
-
-                Logic.api.setConfig("instance", account.instance)
-                Logic.api.setConfig("api_user_token", account.api_user_token)
-
-                Logic.clearModels()
                 if (removing)
                     accountsList.model = Logic.conf.accounts
                 else activeAccountChanged()

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -78,6 +78,7 @@ Page {
                                     Logic.conf['login'] = false
                                     Logic.conf['instance'] = null;
                                     Logic.conf['api_user_token'] = null;
+                                    Logic.conf['type'] = null
                                 }
                                 pageStack.push(Qt.resolvedUrl("LoginPage.qml"))
                             })

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -52,7 +52,7 @@ Page {
 
                 Logic.api.setConfig("instance", account.instance)
                 Logic.api.setConfig("api_user_token", account.api_user_token)
-                console.log(JSON.stringify(account))
+                Logic.clearModels()
 
                 pageStack.pop(null, PageStackAction.Immediate)
                 pageStack.replace(Qt.resolvedUrl("MainPage.qml"), null, PageStackAction.Immediate)

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -285,7 +285,7 @@ Page {
 
                         ListElement {
                             name: "roundedrectangle"
-                            desc: qsTr("Pixelfed support")
+                            desc: qsTr("Development")
                             mastodon: "roundedrectangle@techhub.social"
                             mail: ""
                         }
@@ -307,7 +307,7 @@ Page {
                                 if (model.mastodon !== ""){
                                     var m = Qt.createQmlObject('import QtQuick 2.0; ListModel { }', Qt.application, 'InternalQmlObject');
                                     pageStack.push(Qt.resolvedUrl("ConversationPage.qml"), {
-                                                       headerTitle: "Mention",
+                                                       headerTitle: qsTr("Mention"),
                                                        username: '@'+model.mastodon,
                                                        type: "new"
                                                    })

--- a/qml/pages/components/HoldInteractionHint.qml
+++ b/qml/pages/components/HoldInteractionHint.qml
@@ -1,0 +1,61 @@
+import QtQuick 2.2
+import Sailfish.Silica 1.0
+
+Icon {
+    id: hint
+    color: palette.primaryColor
+    source: "image://theme/graphic-gesture-hint"
+
+    property alias running: animation.running
+    property alias loops: animation.loops
+
+    opacity: 0
+    scale: 1.5
+
+    onRunningChanged: {
+        if (!running) opacity = 0
+    }
+
+    SequentialAnimation {
+        id: animation
+        loops: Animation.Infinite
+
+        PauseAnimation { duration: 2000 }
+
+        ParallelAnimation {
+            OpacityAnimator {
+                target: hint
+                from: 0.0
+                to: 1.0
+                duration: 300
+            }
+
+            ScaleAnimator {
+                target: hint
+                from: 1.0
+                to: 0.75
+                //easing.type: Easing.OutInQuad
+                duration: 300
+            }
+        }
+
+        PauseAnimation { duration: 1000 }
+
+        ParallelAnimation {
+            OpacityAnimator {
+                target: hint
+                from: 1.0
+                to: 0.0
+                duration: 300
+            }
+
+            ScaleAnimator {
+                target: hint
+                from: 0.75
+                to: 1.0
+                //easing.type: Easing.InOutQuad
+                duration: 300
+            }
+        }
+    }
+}

--- a/qml/pages/components/ItemUser.qml
+++ b/qml/pages/components/ItemUser.qml
@@ -5,8 +5,6 @@ import Sailfish.Silica 1.0
 BackgroundItem {
     id: delegate
 
-    signal openUser (string notice)
-
     width: parent.width
     height: Theme.itemSizeMedium
 
@@ -84,20 +82,4 @@ BackgroundItem {
             anchors.top: display_name.bottom
         }
     }
-
-    onClicked: openUser( {
-                            "display_name": model.account_display_name,
-                            "username": model.account_acct,
-                            "user_id": model.account_id,
-                            "profileImage": model.account_avatar,
-                            "profileBackground": model.account_header,
-                            "note": model.account_note,
-                            "url": model.account_url,
-                            "followers_count": model.account_followers_count,
-                            "following_count": model.account_following_count,
-                            "statuses_count": model.account_statuses_count,
-                            "locked": model.account_locked,
-                            "bot": model.account_bot,
-                            "group": model.account_group
-                        } )
 }

--- a/qml/pages/components/ItemUser.qml
+++ b/qml/pages/components/ItemUser.qml
@@ -64,7 +64,7 @@ BackgroundItem {
         Label {
             id: display_name
             text: model.account_display_name ? model.account_display_name : model.account_username.split('@')[0]
-            color: !pressed ? Theme.primaryColor : Theme.highlightColor
+            color: !highlighted ? Theme.primaryColor : Theme.highlightColor
             font.pixelSize: Theme.fontSizeSmall
             truncationMode: TruncationMode.Fade
             width: parent.width - Theme.paddingMedium
@@ -74,7 +74,7 @@ BackgroundItem {
         Label {
             id: account_acct
             text: "@"+model.account_acct
-            color: !pressed ?  Theme.secondaryColor : Theme.secondaryHighlightColor
+            color: !highlighted ?  Theme.secondaryColor : Theme.secondaryHighlightColor
             anchors.leftMargin: Theme.paddingMedium
             font.pixelSize: Theme.fontSizeExtraSmall
             truncationMode: TruncationMode.Fade

--- a/qml/pages/components/ItemUser.qml
+++ b/qml/pages/components/ItemUser.qml
@@ -2,11 +2,13 @@ import QtQuick 2.0
 import Sailfish.Silica 1.0
 
 
-BackgroundItem {
+ListItem {
     id: delegate
 
+    property bool textHighlighted
+
     width: parent.width
-    height: Theme.itemSizeMedium
+    contentHeight: Theme.itemSizeMedium
 
     Item {
         id: avatar
@@ -64,7 +66,7 @@ BackgroundItem {
         Label {
             id: display_name
             text: model.account_display_name ? model.account_display_name : model.account_username.split('@')[0]
-            color: !highlighted ? Theme.primaryColor : Theme.highlightColor
+            color: highlighted || textHighlighted ? Theme.highlightColor : Theme.primaryColor
             font.pixelSize: Theme.fontSizeSmall
             truncationMode: TruncationMode.Fade
             width: parent.width - Theme.paddingMedium
@@ -74,7 +76,7 @@ BackgroundItem {
         Label {
             id: account_acct
             text: "@"+model.account_acct
-            color: !highlighted ?  Theme.secondaryColor : Theme.secondaryHighlightColor
+            color: highlighted || textHighlighted ? Theme.secondaryHighlightColor : Theme.secondaryColor
             anchors.leftMargin: Theme.paddingMedium
             font.pixelSize: Theme.fontSizeExtraSmall
             truncationMode: TruncationMode.Fade

--- a/qml/pages/components/ItemUser.qml
+++ b/qml/pages/components/ItemUser.qml
@@ -63,7 +63,7 @@ BackgroundItem {
 
         Label {
             id: display_name
-            text: account_display_name ? account_display_name : account_username.split('@')[0]
+            text: model.account_display_name ? model.account_display_name : model.account_username.split('@')[0]
             color: !pressed ? Theme.primaryColor : Theme.highlightColor
             font.pixelSize: Theme.fontSizeSmall
             truncationMode: TruncationMode.Fade

--- a/qml/pages/components/MyList.qml
+++ b/qml/pages/components/MyList.qml
@@ -95,7 +95,7 @@ SilicaListView {
 
         MenuItem {
             text: qsTr("Open in Browser")
-            visible: !mainPage
+            visible: typeof mainPage === 'undefined'
             onClicked: {
                 Qt.openUrlExternally(url)
             }

--- a/qml/pages/components/MyList.qml
+++ b/qml/pages/components/MyList.qml
@@ -127,6 +127,7 @@ SilicaListView {
 
         /*contentY = scrollOffset
         console.log("CountChanged!")*/
+        if (count == 0) loadData("prepend")
     }
 
     footer: Item {

--- a/qml/pages/components/MyList.qml
+++ b/qml/pages/components/MyList.qml
@@ -50,26 +50,22 @@ SilicaListView {
 
     BusyLabel {
         id: myListBusyLabel
-        running: model.count === 0
+        running: model.count === 0 && timeoutTimer.running && !remove.running
         anchors {
             horizontalCenter: parent.horizontalCenter
             verticalCenter: parent.verticalCenter
         }
 
         Timer {
+            id: timeoutTimer
             interval: 5000
             running: true
-            onTriggered: {
-                myListBusyLabel.visible = false
-                loadStatusPlaceholder.visible = true
-            }
         }
     }
 
     ViewPlaceholder {
         id: loadStatusPlaceholder
-        visible: false
-        enabled: model.count === 0
+        enabled: model.count === 0 && !myListBusyLabel.running && !remove.running
         text: qsTr("Nothing found")
     }
 
@@ -127,7 +123,10 @@ SilicaListView {
 
         /*contentY = scrollOffset
         console.log("CountChanged!")*/
-        if (count == 0) loadData("prepend")
+        if (count === 0) {
+            loadData("prepend")
+            timeoutTimer.start()
+        }
     }
 
     footer: Item {

--- a/qml/pages/components/NavigationPanel.qml
+++ b/qml/pages/components/NavigationPanel.qml
@@ -14,17 +14,17 @@ SilicaGridView {
     readonly property real menuHeight: headerItem.implicitHeight
     readonly property var menuItem: headerItem._menuItem
 
+    property Component menu
+
     onSlideshowIndexChanged: {
         navigateTo(vIndex)
     }
 
-    header: ListItem {
+    header: Component { ListItem {
         width: parent.width
         contentHeight: 0
-        menu: Component { ContextMenu {
-            // ...
-        } }
-    }
+        menu: gridView.menu
+    } }
 
     ListModel {
         id: listModel

--- a/qml/pages/components/NavigationPanel.qml
+++ b/qml/pages/components/NavigationPanel.qml
@@ -13,20 +13,31 @@ SilicaGridView {
 
     property var dockedPanelMouseArea
     readonly property real menuHeight: headerItem.implicitHeight
-    readonly property var menuItem: headerItem._menuItem
-
-    property Component menu
     property bool showInteractionHintLabel
 
     onSlideshowIndexChanged: {
         navigateTo(vIndex)
     }
 
-    header: Component { ListItem {
-        width: parent.width
-        contentHeight: 0
-        menu: gridView.menu
-    } }
+    header: Component {
+        ListItem {
+            width: parent.width
+            contentHeight: 0
+            menu: Component {
+                ContextMenu {
+                    hasContent: Logic.conf.accounts.length > 1
+                    Repeater {
+                        model: Logic.conf.accounts
+                        MenuItem {
+                            enabled: index !== Logic.conf.activeAccount
+                            text: modelData.userInfo.account_acct
+                            onClicked: Logic.setActiveAccount(index)
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     ListModel {
         id: listModel
@@ -159,7 +170,7 @@ SilicaGridView {
 
 
                 headerItem.openMenu()
-                running = menuItem.hasContent
+                running = headerItem._menuItem.hasContent
                 headerItem.closeMenu()
 
                 if (running)
@@ -201,9 +212,9 @@ SilicaGridView {
     Connections {
         // Forward events from docked panel to context menu
         target: dockedPanelMouseArea
-        onPositionChanged: if (menuItem)
-            menuItem._updatePosition(menuItem._contentColumn.mapFromItem(dockedPanelMouseArea, dockedPanelMouseArea.mouseX, dockedPanelMouseArea.mouseY).y)
-        onReleased: if (menuItem) menuItem.released(mouse)
+        onPositionChanged: if (headerItem._menuItem)
+            headerItem._menuItem._updatePosition(headerItem._menuItem._contentColumn.mapFromItem(dockedPanelMouseArea, dockedPanelMouseArea.mouseX, dockedPanelMouseArea.mouseY).y)
+        onReleased: if (headerItem._menuItem) headerItem._menuItem.released(mouse)
     }
 
     Binding {

--- a/qml/pages/components/VisualContainer.qml
+++ b/qml/pages/components/VisualContainer.qml
@@ -398,7 +398,7 @@ BackgroundItem {
             onClicked: {
                 pageStack.push(Qt.resolvedUrl("../ConversationPage.qml"), {
                                    headerTitle: qsTr("Mention"),
-                                   description: "@"+reblog_account_acct,
+                                   username: "@"+reblog_account_acct,
                                    type: "new"
                                })
             }


### PR DESCRIPTION
This PR is based on the Pixelfed PR, since that's when support for multiple accounts will be needed. Because Pixelfed PR is not yet merged, this one is marked as draft. If Pixelfed PR will not be merged, this one can be modified to not be based on Pixelfed one.

Changes for multiple accounts support:
- A new array `accounts` in configuration
- If old account configuration exists, it is automatically migrated as a new account
- On startup or when switching accounts (when logged in), current account info is saved to configuration (needed so settings can show avatar, username and other stuff)
- Every account is showed in settings as a separate entry. You can delete an account in the context menu
- A quick account switcher can be opened by pressing and holding the home tab. There is an interaction hint for this available. Menu can only be opened when there is more than one account available
- On login or when switching accounts all models are cleared. When models are cleared, they are automatically updated too (in `MyList`).

Improvements not directly related to multiple accounts support:
- Configuration is now logged with `JSON.stringify` (so the accounts array is not logged as `[object Object]`)
- `params` in Worker.js can be `null` or `undefined` now
- Improvements to ItemUser
    - Removed an unused signal `openUser`
    - Changed the base to `ListItem` (so menu can be added)
    - Added `textHighlighted` property
    - Only use `model` for accessing account attributes
- The page stack is fully cleared before pushing main page on login
- Removed a warning in console for `MyList`