### PR TITLE
Fix workflow not running on pull request

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - '1.*'
   pull_request:
     branches:
-      - main
+      - master
 env:
   RELEASE: 5.0.0.43
 


### PR DESCRIPTION
An alternative to this change would be to rename the `master` branch to `main` (IIRC, this can be done in the repository settings).